### PR TITLE
Update import in anticipation of IPython deprecation

### DIFF
--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -7,7 +7,7 @@ c.Spawner.use_docker_client_env = True
 c.Spawner.container_ip = '192.168.99.100'
 c.Spawner.remove_containers = True
 
-from IPython.utils.localinterfaces import public_ips
+from jupyter_client.localinterfaces import public_ips
 c.JupyterHub.ip = public_ips()[0]
 c.JupyterHub.hub_ip = public_ips()[0] 
 c.JupyterHub.hub_api_ip = public_ips()[0]


### PR DESCRIPTION
Since `IPython` will be deprecated soon, it's best to use `jupyter_client` when using the `localinterfaces` module.
